### PR TITLE
Add sidebar for recent diary entries

### DIFF
--- a/emotional-diary (2).html
+++ b/emotional-diary (2).html
@@ -374,6 +374,27 @@
                 max-height: 200px;
             }
         }
+        .recent-sidebar {
+            position: fixed;
+            top: 0;
+            right: 0;
+            width: 240px;
+            height: 100vh;
+            overflow-y: auto;
+            background: rgba(255, 255, 255, 0.95);
+            border-left: 1px solid #e2e8f0;
+            padding: 1rem;
+            box-shadow: -2px 0 8px rgba(0,0,0,0.05);
+            display: none;
+            z-index: 100;
+        }
+
+        .sidebar-title {
+            font-size: 1.1rem;
+            margin-bottom: 1rem;
+            color: #4a5568;
+            text-align: center;
+        }
     </style>
 </head>
 <body>
@@ -409,6 +430,7 @@
             </div>
         </div>
     </div>
+    <aside id="recentSidebar" class="recent-sidebar"></aside>
 
     <script>
         // Memory storage for demonstration (works here but won't persist)
@@ -483,6 +505,7 @@
                 
                 loadBackgroundImage();
                 loadEntries();
+                renderRecentSidebar();
                 setupEventListeners();
             } catch (error) {
                 console.error('앱 초기화 중 오류:', error);
@@ -643,6 +666,7 @@
                 
                 // Reload entries display
                 loadEntries();
+                renderRecentSidebar();
                 
                 // Show success message
                 showMessage('감정이 저장되었습니다! ✨');
@@ -674,6 +698,7 @@
                         <div class="entry-text">${escapeHtml(entry.text)}</div>
                     </div>
                 `).join('');
+                renderRecentSidebar();
             } catch (error) {
                 console.error('항목 로드 오류:', error);
                 document.getElementById('entriesList').innerHTML = '<div class="no-entries">항목을 불러오는데 실패했습니다.</div>';
@@ -717,5 +742,6 @@
             }, timeout);
         }
     </script>
+    <script src="recentSidebar.js"></script>
 </body>
 </html>

--- a/recentSidebar.js
+++ b/recentSidebar.js
@@ -1,0 +1,21 @@
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+function renderRecentSidebar() {
+    const sidebar = document.getElementById('recentSidebar');
+    if (!sidebar)
+        return;
+    const entries = JSON.parse(getFromStorage('emotionalDiaryEntries', '[]'));
+    if (entries.length === 0) {
+        sidebar.style.display = 'none';
+        return;
+    }
+    sidebar.style.display = 'block';
+    const recent = entries.slice(0, 3);
+    sidebar.innerHTML = '<h2 class="sidebar-title">최근 감정</h2>' +
+        recent.map(e => `\n        <div class="entry">\n            <div class="entry-date">${escapeHtml(e.date)}</div>\n            <div class="entry-text">${escapeHtml(e.text)}</div>\n        </div>`).join('');
+}
+window.renderRecentSidebar = renderRecentSidebar;
+document.addEventListener('DOMContentLoaded', renderRecentSidebar);

--- a/recentSidebar.ts
+++ b/recentSidebar.ts
@@ -1,0 +1,32 @@
+interface DiaryEntry {
+    id: number;
+    date: string;
+    text: string;
+    timestamp: number;
+}
+
+declare function getFromStorage(key: string, defaultValue?: string): string;
+
+function escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function renderRecentSidebar(): void {
+    const sidebar = document.getElementById('recentSidebar');
+    if (!sidebar) return;
+    const entries: DiaryEntry[] = JSON.parse(getFromStorage('emotionalDiaryEntries', '[]'));
+    if (entries.length === 0) {
+        sidebar.style.display = 'none';
+        return;
+    }
+    sidebar.style.display = 'block';
+    const recent = entries.slice(0, 3);
+    sidebar.innerHTML = '<h2 class="sidebar-title">최근 감정</h2>' +
+        recent.map(e => `\n        <div class="entry">\n            <div class="entry-date">${escapeHtml(e.date)}</div>\n            <div class="entry-text">${escapeHtml(e.text)}</div>\n        </div>`).join('');
+}
+
+(window as any).renderRecentSidebar = renderRecentSidebar;
+
+document.addEventListener('DOMContentLoaded', renderRecentSidebar);


### PR DESCRIPTION
## Summary
- add TypeScript module to render latest diary entries in sidebar
- update diary HTML to show sidebar on all pages
- call sidebar rendering after loading or saving entries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f6b520c60832e8658a6f503d69f3f